### PR TITLE
hotfix replace carbon parse with createFromFormat

### DIFF
--- a/app/Author.php
+++ b/app/Author.php
@@ -13,6 +13,6 @@ class Author extends Model
 
     public function setDobAttribute($dob)
     {
-        $this->attributes['dob'] = Carbon::parse($dob);
+        $this->attributes['dob'] = Carbon::createFromFormat('m/d/Y', $dob);
     }
 }

--- a/app/Http/Controllers/AuthorsController.php
+++ b/app/Http/Controllers/AuthorsController.php
@@ -21,7 +21,7 @@ class AuthorsController extends Controller
     {
         return request()->validate([
             'name' => 'required',
-            'dob' => 'required',
+            'dob' => 'required|date_format:m/d/Y',
         ]);
     }
 }

--- a/tests/Feature/AuthorManagementTest.php
+++ b/tests/Feature/AuthorManagementTest.php
@@ -15,6 +15,8 @@ class AuthorManagementTest extends TestCase
     /** @test */
     public function an_author_can_be_created()
     {
+        $this->withoutExceptionHandling();
+        
         $this->post('/authors', $this->data());
 
         $author = Author::all();


### PR DESCRIPTION
This fix because when upgrade laravel to version 7, it will throw exception

`Exception: DateTime::__construct(): Failed to parse time string (19/05/1989) at position 0 (1): Unexpected character`